### PR TITLE
documentation link was invalid

### DIFF
--- a/ios/documentation/index.md
+++ b/ios/documentation/index.md
@@ -8,7 +8,7 @@ The Storekit module allows you access to Apple's in-app purchasing mechanisms.
 
 Read our Wiki page to get started quickly:
 
-[http://wiki.appcelerator.org/display/guides/StoreKit+Module+In-App+Purchase+Testing](http://wiki.appcelerator.org/display/guides/StoreKit+Module+In-App+Purchase+Testing)
+[StoreKit Module In-App Purchase Testing](https://wiki.appcelerator.org/pages/viewpage.action?pageId=27591081)
 
 ## Getting Started
 


### PR DESCRIPTION
Updated the link to no longer point to a not found wiki page.
I know this is a trivial change, but there are less trivial pull requests coming. I am still getting unrecognized selector exceptions ( fixes in soon to be filed PRs). 