### PR TITLE
Replaced /titanium﻿ with /platform﻿ in URLs

### DIFF
--- a/ios/documentation/index.md
+++ b/ios/documentation/index.md
@@ -12,7 +12,7 @@ Read our Wiki page to get started quickly:
 
 ## Getting Started
 
-View the [Using Titanium Modules](http://docs.appcelerator.com/titanium/latest/#!/guide/Using_Titanium_Modules) document for instructions on getting
+View the [Using Titanium Modules](http://docs.appcelerator.com/platform/latest/#!/guide/Using_Titanium_Modules) document for instructions on getting
 started with using this module in your application.
 
 ## Accessing the Storekit Module


### PR DESCRIPTION
Replaced `../titanium﻿..` with `../platform﻿..` in any and all URLs of this yaml file.

https://jira.appcelerator.org/browse/MOD-2124